### PR TITLE
Shorthand font style doesn't parse

### DIFF
--- a/lib/properties/fontFamily.js
+++ b/lib/properties/fontFamily.js
@@ -6,7 +6,7 @@ var valueType = require('../parsers').valueType;
 var partsRegEx = /\s*,\s*/;
 module.exports.isValid = function isValid(v) {
     var parts = v.split(partsRegEx);
-    var len = parts.len;
+    var len = parts.length;
     var i;
     var type;
     for (i = 0; i < len; i++) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -95,15 +95,15 @@ module.exports = {
         test.ok('url(http://www.example.com/some_img.jpg)' === style.backgroundImage, 'backgroundImage is wrong');
         test.ok('blue url(http://www.example.com/some_img.jpg)' === style.background, 'background is different');
         style.border = '0 solid black';
-        test.ok('0px', style.borderWidth, 'borderWidth is not 0px');
-        test.ok('solid', style.borderStyle, 'borderStyle is not solid');
-        test.ok('black', style.borderColor, 'borderColor is not black');
-        test.ok('0px', style.borderTopWidth, 'borderTopWidth is not 0px');
-        test.ok('solid', style.borderLeftStyle, 'borderLeftStyle is not solid');
-        test.ok('black', style.borderBottomColor, 'borderBottomColor is not black');
+        test.ok('0px' === style.borderWidth, 'borderWidth is not 0px');
+        test.ok('solid' === style.borderStyle, 'borderStyle is not solid');
+        test.ok('black' === style.borderColor, 'borderColor is not black');
+        test.ok('0px' === style.borderTopWidth, 'borderTopWidth is not 0px');
+        test.ok('solid' === style.borderLeftStyle, 'borderLeftStyle is not solid');
+        test.ok('black' === style.borderBottomColor, 'borderBottomColor is not black');
         style.font = '12em monospace';
-        test.ok('12em', style.fontSize, 'fontSize is not 12em');
-        test.ok('monospace', style.fontFamily, 'fontFamily is not monospace');
+        test.ok('12em' === style.fontSize, 'fontSize is not 12em');
+        test.ok('monospace' === style.fontFamily, 'fontFamily is not monospace');
         test.done();
     },
     'Test width and height Properties and null and empty strings': function (test) {


### PR DESCRIPTION
The font shorthand "12em monospace" doesn't parse. The test case should have picked this up, but the validation API call was wrong. The attached PR fixes the test case validation so it now fails, but it doesn't fix the source of the shorthand parsing error.