### PR TITLE
Improve handling of padding and margin 

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -24,7 +24,7 @@ var numberRegEx = /^[\-+]?[0-9]*\.[0-9]+$/;
 var lengthRegEx = /^(0|[\-+]?[0-9]*\.?[0-9]+(in|cm|em|mm|pt|pc|px))$/;
 var percentRegEx = /^[\-+]?[0-9]*\.?[0-9]+%$/;
 var urlRegEx = /^url\(\s*([^\)]*)\s*\)$/;
-var stringRegEx = /^("[^"]*"|'[^']*')$/;
+var stringRegEx = /^(\"[^\"]*\"|\'[^\']*\')$/;
 var colorRegEx1 = /^#[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])?$/;
 var colorRegEx2 = /^rgb\(([^\)]*)\)$/;
 var colorRegEx3 = /^rgba\(([^\)]*)\)$/;
@@ -432,7 +432,7 @@ var getParts = function (str) {
         closing_index = closing_deliminators.indexOf(str[i]);
         if (is_space.test(str[i])) {
             if (deliminator_stack.length === 0) {
-                parts.push(current_part);
+                if (current_part !== '') parts.push(current_part);
                 current_part = '';
             } else {
                 current_part += str[i];
@@ -560,6 +560,7 @@ exports.implicitSetter = function (property_before, property_after, isValid, par
     if (property_after !== '') {
         property_after = '-' + property_after;
     }
+    var part_names = ["top","right","bottom","left"];
 
     return function (v) {
         if (typeof v === 'number') {
@@ -582,38 +583,18 @@ exports.implicitSetter = function (property_before, property_after, isValid, par
             return undefined;
         }
 
-        this._setProperty(property_before + property_after, parts.map(function (part) { return parser(part); }).join(' '));
+	parts = parts.map(function (part) { return parser(part); });
+        this._setProperty(property_before + property_after, parts.join(' '));
+	if (parts.length === 1) parts[1] = parts[0];
+	if (parts.length === 2) parts[2] = parts[0];
+	if (parts.length === 3) parts[3] = parts[1];
 
-        this.removeProperty(property_before + '-top' + property_after);
-        this.removeProperty(property_before + '-right' + property_after);
-        this.removeProperty(property_before + '-bottom' + property_after);
-        this.removeProperty(property_before + '-left' + property_after);
-        switch (parts.length) {
-        case 1:
-            this._values[property_before + '-top' + property_after] = parser(parts[0]);
-            this._values[property_before + '-right' + property_after] = parser(parts[0]);
-            this._values[property_before + '-bottom' + property_after] = parser(parts[0]);
-            this._values[property_before + '-left' + property_after] = parser(parts[0]);
-            return v;
-        case 2:
-            this._values[property_before + '-top' + property_after] = parser(parts[0]);
-            this._values[property_before + '-right' + property_after] = parser(parts[1]);
-            this._values[property_before + '-bottom' + property_after] = parser(parts[0]);
-            this._values[property_before + '-left' + property_after] = parser(parts[1]);
-            return v;
-        case 3:
-            this._values[property_before + '-top' + property_after] = parser(parts[0]);
-            this._values[property_before + '-right' + property_after] = parser(parts[1]);
-            this._values[property_before + '-bottom' + property_after] = parser(parts[2]);
-            this._values[property_before + '-left' + property_after] = parser(parts[1]);
-            return v;
-        case 4:
-            this._values[property_before + '-top' + property_after] = parser(parts[0]);
-            this._values[property_before + '-right' + property_after] = parser(parts[1]);
-            this._values[property_before + '-bottom' + property_after] = parser(parts[2]);
-            this._values[property_before + '-left' + property_after] = parser(parts[3]);
-            return v;
-        }
+	for (var i = 0; i < 4; i++) {
+	    var property = property_before + "-" + part_names[i] + property_after;
+	    this.removeProperty(property);
+	    if (parts[i] !== '') this._values[property] = parts[i];
+	}
+	return v;
     };
 };
 

--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -1,8 +1,38 @@
 'use strict';
 
+var parsers = require('../parsers.js');
+var TYPES = parsers.TYPES;
+
+var isValid = function (v) {
+    if (v.toLowerCase() === "auto") return true;
+    var type = parsers.valueType(v);
+    return type === TYPES.LENGTH || type === TYPES.PERCENT;
+};
+
+var parser = function (v) {
+    var V = v.toLowerCase();
+    if (V === "auto") return V;
+    return parsers.parseMeasurement(v);
+}
+
+var mySetter = parsers.implicitSetter('margin', '', isValid, parser);
+var myGlobal = parsers.implicitSetter('margin', '', function () {return true}, function (v) {return v});
+
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('margin', v);
+        var V = v.toLowerCase();
+        switch (V) {
+          case 'inherit':
+          case 'initial':
+          case 'unset':
+          case '':
+            myGlobal.call(this, V);
+            break;
+
+          default:
+            mySetter.call(this, v);
+            break;
+        }
     },
     get: function () {
         return this.getPropertyValue('margin');

--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -20,6 +20,8 @@ var myGlobal = parsers.implicitSetter('margin', '', function () {return true}, f
 
 module.exports.definition = {
     set: function (v) {
+	if (typeof v === "number") v = String(v);
+	if (typeof v !== "string") return;
         var V = v.toLowerCase();
         switch (V) {
           case 'inherit':

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -17,6 +17,8 @@ var myGlobal = parsers.implicitSetter('padding', '', function () {return true}, 
 
 module.exports.definition = {
     set: function (v) {
+	if (typeof v === "number") v = String(v);
+	if (typeof v !== "string") return;
         var V = v.toLowerCase();
         switch (V) {
           case 'inherit':

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -1,8 +1,35 @@
 'use strict';
 
+var parsers = require('../parsers.js');
+var TYPES = parsers.TYPES;
+
+var isValid = function (v) {
+    var type = parsers.valueType(v);
+    return type === TYPES.LENGTH || type === TYPES.PERCENT;
+};
+
+var parser = function (v) {
+    return parsers.parseMeasurement(v);
+}
+
+var mySetter = parsers.implicitSetter('padding', '', isValid, parser);
+var myGlobal = parsers.implicitSetter('padding', '', function () {return true}, function (v) {return v});
+
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('padding', v);
+        var V = v.toLowerCase();
+        switch (V) {
+          case 'inherit':
+          case 'initial':
+          case 'unset':
+          case '':
+            myGlobal.call(this, V);
+            break;
+
+          default:
+            mySetter.call(this, v);
+            break;
+        }
     },
     get: function () {
         return this.getPropertyValue('padding');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -188,11 +188,14 @@ module.exports = {
     },
     'Test short hand properties with embedded spaces': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
-        test.expect(3);
+        test.expect(4);
         style.background = 'rgb(0, 0, 0) url(/something/somewhere.jpg)';
         test.ok('rgb(0, 0, 0)' === style.backgroundColor, 'backgroundColor is not rgb(0, 0, 0): ' + style.backgroundColor);
         test.ok('url(/something/somewhere.jpg)' === style.backgroundImage, 'backgroundImage is not url(/something/somewhere.jpg): ' + style.backgroundImage);
         test.ok('background: rgb(0, 0, 0) url(/something/somewhere.jpg);' === style.cssText, 'cssText is not correct: ' + style.cssText);
+        style = new cssstyle.CSSStyleDeclaration();
+        style.border = '  1px  solid   black  ';
+        test.ok('1px solid black' === style.border, 'multiple spaces not properly parsed: ' + style.border);
         test.done();
     },
     'Setting shorthand properties to an empty string should clear all dependent properties': function (test) {
@@ -276,6 +279,33 @@ module.exports = {
         test.ok('opacity: 0.5;' === style.cssText, 'cssText is not "opacity: 0.5;": ' + style.cssText);
         style.opacity = 1.0;
         test.ok('opacity: 1;' === style.cssText, 'cssText is not "opacity: 1;": ' + style.cssText);
+        test.done();
+    },
+    'Padding and margin should set/clear shorthand properties': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        var parts = ["Top","Right","Bottom","Left"];
+        var testParts = function (name,v,V) {
+            style[name] = v;
+            for (var i = 0; i < 4; i++) {
+                var part = name + parts[i];
+                test.ok(V[i] === style[part], part + ' is not "' + V[i] + '": ' + style[part]);
+            }
+            test.ok(v === style[name], name + ' is not "' + v + '": ' + style[name]);
+            style[name] = "";
+        };
+        test.expect(50);
+        testParts("padding","1px",["1px","1px","1px","1px"]);
+        testParts("padding","1px 2%",["1px","2%","1px","2%"]);
+        testParts("padding","1px 2px 3px",["1px","2px","3px","2px"]);
+        testParts("padding","1px 2px 3px 4px",["1px","2px","3px","4px"]);
+        style.paddingTop = style.paddingRight = style.paddingBottom = style.paddingLeft = "1px";
+        testParts("padding","",["","","",""]);
+        testParts("margin","1px",["1px","1px","1px","1px"]);
+        testParts("margin","1px auto",["1px","auto","1px","auto"]);
+        testParts("margin","1px 2% 3px",["1px","2%","3px","2%"]);
+        testParts("margin","1px 2px 3px 4px",["1px","2px","3px","4px"]);
+        style.marginTop = style.marginRight = style.marginBottom = style.marginLeft = "1px";
+        testParts("margin","",["","","",""]);
         test.done();
     },
     'Setting a value to 0 should return the string value': function (test) {


### PR DESCRIPTION
This pull request improves the handling of `padding` and `margin`.  They now set and clear the `-top`, `-right`, `-bottom`, and `-left` properties properly, and validate the value they are set to.  It also adds some tests to verify that this works.

As part of the update, the `implicitSetter()` function is simplified, and made more efficient (the `parser` function is only called once on any of the parts).  Also, unneeded empty parts are not retained in the `_values` array.  Finally, `getParts()` now allows multiple spaces as separators.