### PR TITLE
Allow width and height to be set to auto

### DIFF
--- a/lib/properties/height.js
+++ b/lib/properties/height.js
@@ -2,9 +2,16 @@
 
 var parseMeasurement = require('../parsers').parseMeasurement;
 
+function parse(v) {
+    if (String(v).toLowerCase() === "auto") {
+        return "auto";
+    }
+    return parseMeasurement(v);
+}
+
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('height', parseMeasurement(v));
+        this._setProperty('height', parse(v));
     },
     get: function () {
         return this.getPropertyValue('height');

--- a/lib/properties/width.js
+++ b/lib/properties/width.js
@@ -2,9 +2,16 @@
 
 var parseMeasurement = require('../parsers').parseMeasurement;
 
+function parse(v) {
+    if (String(v).toLowerCase() === "auto") {
+        return "auto";
+    }
+    return parseMeasurement(v);
+}
+
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('width', parseMeasurement(v));
+        this._setProperty('width', parse(v));
     },
     get: function () {
         return this.getPropertyValue('width');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -281,6 +281,18 @@ module.exports = {
         test.ok('opacity: 1;' === style.cssText, 'cssText is not "opacity: 1;": ' + style.cssText);
         test.done();
     },
+    'Width and height of auto shoud work': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(4);
+        style.width = "auto";
+        test.equal(style.cssText,'width: auto;', 'cssText is not "width: auto;": ' + style.cssText);
+        test.equal(style.width,'auto', 'width is not "auto": ' + style.width);
+        style = new cssstyle.CSSStyleDeclaration();
+        style.height = "auto";
+        test.equal(style.cssText,'height: auto;', 'cssText is not "height: auto;": ' + style.cssText);
+        test.equal(style.height,'auto', 'height is not "auto": ' + style.height);
+        test.done();
+    },
     'Padding and margin should set/clear shorthand properties': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
         var parts = ["Top","Right","Bottom","Left"];


### PR DESCRIPTION
Allow `width` and `height` to be set to `auto`, and add new test to verify the fix.  Resolves issue #40.